### PR TITLE
Recognizer setup method was not taking into account original start options

### DIFF
--- a/demo/app/tests/internal/activity-recognition/recognizers/index.ts
+++ b/demo/app/tests/internal/activity-recognition/recognizers/index.ts
@@ -6,6 +6,7 @@ import {
     Resolution,
     HumanActivity,
 } from "nativescript-context-apis/internal/activity-recognition";
+import { StartOptions } from "nativescript-context-apis/internal/activity-recognition/recognizers";
 import { RecognizerManager } from "nativescript-context-apis/internal/activity-recognition/recognizers/recognizer-manager";
 
 export function createCallbackManagerMock(): RecognizerCallbackManager {
@@ -30,7 +31,13 @@ export function createRecognizersStateStoreMock(): RecognizerStateStore {
         isActive(recognizer: Resolution): Promise<boolean> {
             return Promise.resolve(false);
         },
-        markAsActive(recognizer: Resolution): Promise<void> {
+        getStartOptions(recognizer: Resolution): Promise<StartOptions> {
+            return Promise.resolve(null);
+        },
+        markAsActive(
+            recognizer: Resolution,
+            startOptions: StartOptions
+        ): Promise<void> {
             return Promise.resolve();
         },
         markAsInactive(recognizer: Resolution): Promise<void> {

--- a/demo/app/tests/internal/activity-recognition/recognizers/state-store.ts
+++ b/demo/app/tests/internal/activity-recognition/recognizers/state-store.ts
@@ -3,6 +3,7 @@ import {
     Resolution,
     HumanActivity,
 } from "nativescript-context-apis/internal/activity-recognition";
+import { StartOptions } from "nativescript-context-apis/internal/activity-recognition/recognizers";
 
 describe("Recognizers state store", () => {
     const recognizer = Resolution.HIGH;
@@ -12,8 +13,28 @@ describe("Recognizers state store", () => {
         expect(isActive == true || isActive == false).toBeTrue();
     });
 
+    it("returns the start options of a recognizer marked as active", async () => {
+        const expectedStartOptions: StartOptions = { detectionInterval: 60000 };
+        await recognizersStateStoreDb.markAsActive(
+            recognizer,
+            expectedStartOptions
+        );
+        const startOptions = await recognizersStateStoreDb.getStartOptions(
+            recognizer
+        );
+        expect(startOptions).toEqual(expectedStartOptions);
+    });
+
+    it("returns no start options when the recognizer is marked as inactive", async () => {
+        await recognizersStateStoreDb.markAsInactive(recognizer);
+        const startOptions = await recognizersStateStoreDb.getStartOptions(
+            recognizer
+        );
+        expect(startOptions).toBeNull();
+    });
+
     it("marks a recognizer as active", async () => {
-        await recognizersStateStoreDb.markAsActive(recognizer);
+        await recognizersStateStoreDb.markAsActive(recognizer, {});
         const isActive = await recognizersStateStoreDb.isActive(recognizer);
         expect(isActive).toBeTrue();
     });
@@ -33,7 +54,7 @@ describe("Recognizers state store", () => {
     });
 
     it("successfully updates the last activity of an active recognizer", async () => {
-        await recognizersStateStoreDb.markAsActive(recognizer);
+        await recognizersStateStoreDb.markAsActive(recognizer, {});
         const activity = HumanActivity.RUNNING;
         await recognizersStateStoreDb.updateLastActivity(recognizer, activity);
         const lastActivity = await recognizersStateStoreDb.getLastActivity(

--- a/src/geolocation/index.ts
+++ b/src/geolocation/index.ts
@@ -2,6 +2,7 @@ export {
   getGeolocationProvider,
   GeolocationProvider,
   Geolocation,
+  GeolocationLike,
   AcquireOptions,
   StreamOptions,
 } from "../internal/geolocation";

--- a/src/internal/activity-recognition/recognizers/abstract-recognizer.ts
+++ b/src/internal/activity-recognition/recognizers/abstract-recognizer.ts
@@ -24,13 +24,16 @@ export abstract class AbstractActivityRecognizer implements ActivityRecognizer {
   async setup(): Promise<void> {
     const active = await this.recognizerState.isActive(this.recognizerType);
     if (active) {
-      await this.recognitionManager.startListening();
+      const startOptions = await this.recognizerState.getStartOptions(
+        this.recognizerType
+      );
+      await this.recognitionManager.startListening(startOptions);
     }
   }
 
   async startRecognizing(options: StartOptions = {}): Promise<void> {
     await this.recognitionManager.startListening(options);
-    await this.recognizerState.markAsActive(this.recognizerType);
+    await this.recognizerState.markAsActive(this.recognizerType, options);
   }
 
   async stopRecognizing(): Promise<void> {

--- a/src/internal/activity-recognition/recognizers/state/model.ts
+++ b/src/internal/activity-recognition/recognizers/state/model.ts
@@ -5,6 +5,7 @@ export const recognizersStateModel: InanoSQLTableConfig = {
   model: {
     "id:string": { pk: true },
     "active:boolean": {},
+    "startOptions:string": {},
     "lastActivity:string": {},
   },
 };

--- a/src/internal/geolocation/index.ts
+++ b/src/internal/geolocation/index.ts
@@ -55,7 +55,7 @@ export interface StreamOptions extends AcquireOptions {
   saveBattery?: boolean;
 }
 
-export { Geolocation } from "./geolocation";
+export { Geolocation, GeolocationLike } from "./geolocation";
 
 function geolocationOptionsToPluginOptions(
   options: AcquireOptions | StreamOptions


### PR DESCRIPTION
This pull request aims to fix a bug that showed up when a recognizer was not being started using default options, and in case the device being rebooted or the pending intent being discarded by the Android system.

Now start options become stored as part of the state during recognizer activation and can be recovered as long as it remains active.